### PR TITLE
Fixes for image push + mac

### DIFF
--- a/docker-compose/eigenlayer/docker-compose.yml
+++ b/docker-compose/eigenlayer/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   # Creates a genesis state for the beacon chain using a YAML configuration file and
   # a deterministic set of 64 validators.
@@ -149,7 +148,8 @@ services:
   # FoundaryUp based container with local image
   # deploying EigenLayer Contracts
   eigenlayer:
-    image: "public.ecr.aws/z7q8a4w9/iv1-eigenlayer:latest"
+    platform: linux/amd64
+    image: "public.ecr.aws/ivynet/iv1-eigenlayer:latest"
     command:
       - -vvv
       - --rpc-url

--- a/docker-compose/hello-world-avs/docker-compose.yml
+++ b/docker-compose/hello-world-avs/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   # Creates a genesis state for the beacon chain using a YAML configuration file and
   # a deterministic set of 64 validators.
@@ -149,6 +148,7 @@ services:
   # FoundaryUp based container with local image
   # deploying EigenLayer Contracts
   eigenlayer:
+    platform: linux/amd64
     image: "public.ecr.aws/ivynet/iv1-hw-avs:latest"
     command:
       - -vvv
@@ -175,6 +175,7 @@ services:
   # FoundaryUp based container with local image
   # deploying Demo AVS
   avs-demo:
+    platform: linux/amd64
     image: "public.ecr.aws/ivynet/iv1-hw-avs:latest"
     command:
       - script/HelloWorldDeployer.s.sol
@@ -195,6 +196,7 @@ services:
 
   # Send some money around
   cast:
+    platform: linux/amd64
     image: "ghcr.io/foundry-rs/foundry:nightly-c2e529786c07ee7069cefcd4fe2db41f0e46cef6"
     entrypoint: cast
     command:

--- a/docker-compose/incredible-squaring-avs-full/docker-compose.yml
+++ b/docker-compose/incredible-squaring-avs-full/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   # Creates a genesis state for the beacon chain using a YAML configuration file and
   # a deterministic set of 64 validators.
@@ -150,6 +149,7 @@ services:
   # FoundaryUp based container with local image
   # deploying EigenLayer Contracts
   eigenlayer:
+    platform: linux/amd64
     image: "public.ecr.aws/ivynet/iv1-is-avs:latest"
     command:
       - -vvv
@@ -176,6 +176,7 @@ services:
   # FoundaryUp based container with local image
   # deploying Demo AVS
   avs-demo:
+    platform: linux/amd64
     image: "public.ecr.aws/ivynet/iv1-is-avs:latest"
     command:
       - script/IncredibleSquaringDeployer.s.sol
@@ -196,6 +197,7 @@ services:
 
   # Send some money around
   cast:
+    platform: linux/amd64
     image: "ghcr.io/foundry-rs/foundry:nightly-c2e529786c07ee7069cefcd4fe2db41f0e46cef6"
     entrypoint: cast
     command:

--- a/docker-compose/incredible-squaring-avs/docker-compose.yml
+++ b/docker-compose/incredible-squaring-avs/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   # Creates a genesis state for the beacon chain using a YAML configuration file and
   # a deterministic set of 64 validators.
@@ -149,6 +148,7 @@ services:
   # FoundaryUp based container with local image
   # deploying EigenLayer Contracts
   eigenlayer:
+    platform: linux/amd64
     image: "public.ecr.aws/ivynet/iv1-is-avs:latest"
     command:
       - -vvv
@@ -175,6 +175,7 @@ services:
   # FoundaryUp based container with local image
   # deploying Demo AVS
   avs-demo:
+    platform: linux/amd64
     image: "public.ecr.aws/ivynet/iv1-is-avs:latest"
     command:
       - script/IncredibleSquaringDeployer.s.sol
@@ -195,6 +196,7 @@ services:
 
   # Send some money around
   cast:
+    platform: linux/amd64
     image: "ghcr.io/foundry-rs/foundry:nightly-c2e529786c07ee7069cefcd4fe2db41f0e46cef6"
     entrypoint: cast
     command:

--- a/packer/eigenlayer-deploy.pkr.hcl
+++ b/packer/eigenlayer-deploy.pkr.hcl
@@ -29,9 +29,10 @@ source "docker" "eigenlayer" {
     "ENTRYPOINT [\"forge\", \"script\"]",
     "WORKDIR /eigenlayer",
   ]
-  commit = true
-  image  = "ghcr.io/foundry-rs/foundry:nightly-c2e529786c07ee7069cefcd4fe2db41f0e46cef6"
+  commit   = true
+  image    = "ghcr.io/foundry-rs/foundry:nightly-c2e529786c07ee7069cefcd4fe2db41f0e46cef6"
   platform = "linux/amd64"
+}
 
 build {
   sources = ["source.docker.eigenlayer"]
@@ -51,11 +52,11 @@ build {
     post-processor "docker-tag" {
       repository = "public.ecr.aws/ivynet/iv1-eigenlayer" # (comment it out for local deployment)
       # repository = "ivy-net/iv1-is-avs" # (uncomment it for local deployment)
-      tags       = [var.version, "latest"]
+      tags = [var.version, "latest"]
     }
     post-processor "docker-push" {
-      ecr_login = true
-      aws_profile = "ivy-test"
+      ecr_login    = true
+      aws_profile  = "ivy-test"
       login_server = "public.ecr.aws/ivynet/iv1-eigenlayer"
     }
   }
@@ -89,11 +90,11 @@ build {
     post-processor "docker-tag" {
       repository = "public.ecr.aws/ivynet/iv1-is-avs" # (comment it out for local deployment)
       # repository = "ivy-net/iv1-is-avs" (uncomment it for local deployment)
-      tags       = [var.version, "latest"]
+      tags = [var.version, "latest"]
     }
     post-processor "docker-push" {
-      ecr_login = true
-      aws_profile = "ivy-test"
+      ecr_login    = true
+      aws_profile  = "ivy-test"
       login_server = "public.ecr.aws/ivynet/iv1-is-avs"
     }
   }
@@ -124,12 +125,12 @@ build {
     post-processor "docker-tag" {
       repository = "public.ecr.aws/ivynet/iv1-hw-avs" # (comment it out for local deployment)
       # repository = "ivy-net/iv1-hw-avs" (uncomment it for local deployment)
-      tags       = [var.version, "latest"]
+      tags = [var.version, "latest"]
     }
-    #    post-processor "docker-push" {
-    #      ecr_login = true
-    #      aws_profile = "ivy-test"
-    #      login_server = "public.ecr.aws/ivynet/iv1-hw-avs"
-    #    }
+    post-processor "docker-push" {
+      ecr_login    = true
+      aws_profile  = "ivy-test"
+      login_server = "public.ecr.aws/ivynet/iv1-hw-avs"
+    }
   }
 }


### PR DESCRIPTION
- add a push command for hw image in packer
- add platform for forge and forge based images (so they work on mac)
- remove version from docker-compose (to address the obsolete warning)